### PR TITLE
Added if condition for ttf font-types to include 'truetype' in CSS format

### DIFF
--- a/mixin.scss
+++ b/mixin.scss
@@ -31,13 +31,12 @@ $fonts-path: '../fonts' !default;
 	$src: (local('☺'));
 	$family-folder: str-replace($font-family, ' ', '-');
 	@each $type in $font-types {
+		$format-type: $type;
 		@if $type == 'ttf' {
-			// Allows ttf fonts to be correctly included in CSS
-			$ttf-type: 'truetype';
-			$src: append($src, url('#{$fonts-path}/#{$font-family}/#{nth($font-file, 1)}.#{$type}') format('#{$ttf-type}'), 'comma');
-		} @else {
-			$src: append($src, url('#{$fonts-path}/#{$font-family}/#{nth($font-file, 1)}.#{$type}') format('#{$type}'), 'comma');
+			//Allows ttf fonts to be correctly included in CSS
+			$format-type: 'truetype';
 		}
+		$src: append($src, url('#{$fonts-path}/#{$font-family}/#{nth($font-file, 1)}.#{$type}') format('#{$format-type}'), 'comma');
 	}
 	@return $src;
 }

--- a/mixin.scss
+++ b/mixin.scss
@@ -31,7 +31,13 @@ $fonts-path: '../fonts' !default;
 	$src: (local('☺'));
 	$family-folder: str-replace($font-family, ' ', '-');
 	@each $type in $font-types {
-		$src: append($src, url('#{$fonts-path}/#{$font-family}/#{nth($font-file, 1)}.#{$type}') format('#{$type}'), 'comma');
+		@if $type == 'ttf' {
+			// Allows ttf fonts to be correctly included in CSS
+			$ttf-type: 'truetype';
+			$src: append($src, url('#{$fonts-path}/#{$font-family}/#{nth($font-file, 1)}.#{$type}') format('#{$ttf-type}'), 'comma');
+		} @else {
+			$src: append($src, url('#{$fonts-path}/#{$font-family}/#{nth($font-file, 1)}.#{$type}') format('#{$type}'), 'comma');
+		}
 	}
 	@return $src;
 }

--- a/tests/generator/generator.test.css
+++ b/tests/generator/generator.test.css
@@ -1,36 +1,36 @@
 @charset "UTF-8";
 @font-face {
   font-family: "Open Sans";
-  src: local("☺"), url("/path/to/fonts/Open Sans/open-sans-light.woff2") format("woff2"), url("/path/to/fonts/Open Sans/open-sans-light.woff") format("woff");
+  src: local("☺"), url("/path/to/fonts/Open Sans/open-sans-light.ttf") format("truetype");
   font-weight: 300;
   font-style: normal; }
 
 @font-face {
   font-family: "Open Sans";
-  src: local("☺"), url("/path/to/fonts/Open Sans/open-sans-normal.woff2") format("woff2"), url("/path/to/fonts/Open Sans/open-sans-normal.woff") format("woff");
+  src: local("☺"), url("/path/to/fonts/Open Sans/open-sans-normal.ttf") format("truetype");
   font-weight: 400;
   font-style: normal; }
 
 @font-face {
   font-family: "Open Sans";
-  src: local("☺"), url("/path/to/fonts/Open Sans/open-sans-normal-italic.woff2") format("woff2"), url("/path/to/fonts/Open Sans/open-sans-normal-italic.woff") format("woff");
+  src: local("☺"), url("/path/to/fonts/Open Sans/open-sans-normal-italic.ttf") format("truetype");
   font-weight: 400;
   font-style: italic; }
 
 @font-face {
   font-family: "Open Sans";
-  src: local("☺"), url("/path/to/fonts/Open Sans/open-sans-semibold.woff2") format("woff2"), url("/path/to/fonts/Open Sans/open-sans-semibold.woff") format("woff");
+  src: local("☺"), url("/path/to/fonts/Open Sans/open-sans-semibold.ttf") format("truetype");
   font-weight: 600;
   font-style: normal; }
 
 @font-face {
   font-family: "Open Sans";
-  src: local("☺"), url("/path/to/fonts/Open Sans/open-sans-bold.woff2") format("woff2"), url("/path/to/fonts/Open Sans/open-sans-bold.woff") format("woff");
+  src: local("☺"), url("/path/to/fonts/Open Sans/open-sans-bold.ttf") format("truetype");
   font-weight: 700;
   font-style: normal; }
 
 @font-face {
   font-family: "Font Two";
-  src: local("☺"), url("/path/to/fonts/Font Two/font-two.woff2") format("woff2"), url("/path/to/fonts/Font Two/font-two.woff") format("woff");
+  src: local("☺"), url("/path/to/fonts/Font Two/font-two.ttf") format("truetype");
   font-weight: 400;
   font-style: normal; }

--- a/tests/generator/generator.test.scss
+++ b/tests/generator/generator.test.scss
@@ -15,7 +15,7 @@ $fonts: (
   )
 );
 
-$font-file-types: 'woff2' 'woff';
+$font-file-types: 'ttf';
 
 $fonts-path: '/path/to/fonts';
 

--- a/tests/mixin/mixin.test.css
+++ b/tests/mixin/mixin.test.css
@@ -31,13 +31,13 @@
 
 @font-face {
   font-family: "Font One";
-  src: local("☺"), url("../fonts/Font One/font-one.woff") format("woff");
+  src: local("☺"), url("../fonts/Font One/font-one.ttf") format("truetype");
   font-weight: 400;
   font-style: normal; }
 
 @font-face {
   font-family: "Font Two";
-  src: local("☺"), url("../fonts/Font Two/font-two.woff") format("woff");
+  src: local("☺"), url("../fonts/Font Two/font-two.ttf") format("truetype");
   font-weight: 400;
   font-style: normal; }
 

--- a/tests/mixin/mixin.test.scss
+++ b/tests/mixin/mixin.test.scss
@@ -20,7 +20,9 @@
   'Font Two' : (
     400 : 'font-two'
   )
-));
+),
+$types: 'ttf'
+);
 
 @include font-face(
   $fonts: (


### PR DESCRIPTION
I didn't see any contributors.md file or instructions about sending a PR, so hopefully I'm doing this right.

font-face-generator works well as long as you don't specify ttf as your font type. Problem is that while the extension of that font type is '.ttf', CSS expects 'truetype' format when including the font via font-face. My if condition fixes that issue and adds 'truetype' format in CSS if the font-type parameter is set to 'ttf'.