### PR TITLE
Bugfix: Src path contains spaces in font family name

### DIFF
--- a/mixin.scss
+++ b/mixin.scss
@@ -56,7 +56,7 @@ $fonts-path: '../fonts' !default;
 		}
 		$src: append(
 			$src,
-			url('#{$fonts-path}/#{$font-family}/#{nth($font-file, 1)}.#{$type}')
+			url('#{$fonts-path}/#{$family-folder}/#{nth($font-file, 1)}.#{$type}')
 				format('#{$format-type}'),
 			'comma'
 		);


### PR DESCRIPTION
Bugfix: Src path builder is using the variable $font-family instead of $family-folder variable, so the src could contain spaces instead of the wanted dashes